### PR TITLE
Added gz harmonic + ros humble as multistage build

### DIFF
--- a/ros2-humble/custom/Dockerfile
+++ b/ros2-humble/custom/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:jammy as ros2
 
 # Setup environment
 ENV LANG C.UTF-8
@@ -8,7 +8,10 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES graphics,utility,compute
 ENV TZ=Europe/Zagreb
-ENV ROSCONSOLE_FORMAT '[${severity}] [${time}] [${node}]: ${message}'
+# Not sure this is same in ROS and ROS 2
+#ENV ROSCONSOLE_FORMAT '[${severity}] [${time}] [${node}]: ${message}'
+
+# Fix for apt-get update? 
 
 # Mitigate interactive prompt for choosing keyboard type
 COPY ./to_copy/keyboard /etc/default/keyboard
@@ -16,7 +19,8 @@ COPY ./to_copy/keyboard /etc/default/keyboard
 # Setup timezone (fix interactive package installation)
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone
 
-RUN apt-get update
+#RUN apt remove libappstream4
+#RUN apt-get update
 
 # Install necessary packages for ROS and Gazebo
 RUN apt-get update &&  apt-get install -q -y \
@@ -44,7 +48,6 @@ RUN apt-get update &&  apt-get install -q -y \
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 RUN apt update
-RUN apt upgrade -y
 
 # Install ROS2
 RUN apt install -y \
@@ -62,15 +65,43 @@ COPY ./to_copy/nanorc /root/.nanorc
 COPY ./to_copy/tmux /root/.tmux.conf
 COPY ./to_copy/ranger /root/.config/ranger/rc.conf
 
+# Add developer and add it to sudo group
+RUN adduser --disabled-password --gecos '' developer 
+RUN adduser developer sudo 
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 # Init ROS2 workspace
-RUN mkdir -p ros2_ws/src
-WORKDIR /root/ros2_ws
+RUN mkdir -p /home/developer/ros2_ws/src
+WORKDIR /home/developer/ros2_ws
 RUN colcon build
-WORKDIR /root/ros2_ws/src
+WORKDIR /home/developer/ros2_ws/src
 
 # Modify .bashrc
 RUN echo "" >> ~/.bashrc
 RUN echo "source /opt/ros/${ROS2_DISTRO}/setup.bash" >> ~/.bashrc
-RUN echo "source /root/ros2_ws/install/local_setup.bash" >> ~/.bashrc
+RUN echo "source /home/developer/ros2_ws/install/local_setup.bash" >> ~/.bashrc
+
+# Install gazebo_harmonic
+FROM ros2 as ign_gazebo
+
+# Gazebo installation 
+RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+RUN sudo apt-get update
+RUN sudo apt-get install -y gz-harmonic
+
+# ros2_gz
+RUN sudo apt-get install -y \
+    ros-${ROS2_DISTRO}-ros-ign-bridge \
+    ros-${ROS2_DISTRO}-vision-msgs \
+    libignition-transport11-dev \
+    libignition-gazebo6-dev 
+
+WORKDIR /home/developer/ros2_ws/src
+RUN git clone https://github.com/gazebosim/ros_gz.git -b ${ROS2_DISTRO}
+WORKDIR /home/developer/ros2_ws
+RUN sudo rosdep init
+RUN rosdep update
+RUN rosdep install -r --from-paths src -i -y --rosdistro ${ROS2_DISTRO}
 
 CMD ["bash"]

--- a/ros2-humble/custom/Dockerfile
+++ b/ros2-humble/custom/Dockerfile
@@ -69,19 +69,17 @@ WORKDIR /root/ros2_ws/src
 # Modify .bashrc
 RUN echo "" >> ~/.bashrc
 RUN echo "source /opt/ros/${ROS2_DISTRO}/setup.bash" >> ~/.bashrc
-RUN echo "source /home/developer/ros2_ws/install/local_setup.bash" >> ~/.bashrc
+RUN echo "source /root/ros2_ws/install/local_setup.bash" >> ~/.bashrc
 
 # Install gazebo_harmonic
 FROM ros2 as ign_gazebo
 
 # Gazebo installation 
-RUN sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-RUN sudo apt-get update
-RUN sudo apt-get install -y ignition-fortress
+RUN apt-get update
+RUN apt-get install ros-${ROS2_DISTRO}-ros-gz -y
 
 # ros2_gz
-RUN sudo apt-get install -y \
+RUN apt-get install -y \
     ros-${ROS2_DISTRO}-ros-ign-bridge \
     ros-${ROS2_DISTRO}-vision-msgs \
     ros-${ROS2_DISTRO}-joint-state-publisher \
@@ -93,10 +91,9 @@ RUN sudo apt-get install -y \
     libignition-transport11-dev \
     libignition-gazebo6-dev 
 
-WORKDIR /root/ros2_ws/src
-RUN git clone https://github.com/gazebosim/ros_gz.git -b ${ROS2_DISTRO}
+
 WORKDIR /root/ros2_ws
-RUN sudo rosdep init
+RUN rosdep init
 RUN rosdep update
 RUN rosdep install -r --from-paths src -i -y --rosdistro ${ROS2_DISTRO}
 

--- a/ros2-humble/custom/Dockerfile
+++ b/ros2-humble/custom/Dockerfile
@@ -11,16 +11,11 @@ ENV TZ=Europe/Zagreb
 # Not sure this is same in ROS and ROS 2
 #ENV ROSCONSOLE_FORMAT '[${severity}] [${time}] [${node}]: ${message}'
 
-# Fix for apt-get update? 
-
 # Mitigate interactive prompt for choosing keyboard type
 COPY ./to_copy/keyboard /etc/default/keyboard
 
 # Setup timezone (fix interactive package installation)
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone
-
-#RUN apt remove libappstream4
-#RUN apt-get update
 
 # Install necessary packages for ROS and Gazebo
 RUN apt-get update &&  apt-get install -q -y \
@@ -94,6 +89,9 @@ RUN sudo apt-get install -y gz-harmonic
 RUN sudo apt-get install -y \
     ros-${ROS2_DISTRO}-ros-ign-bridge \
     ros-${ROS2_DISTRO}-vision-msgs \
+    ros-${ROS2_DISTRO}-joint-state-publisher \
+    ros-${ROS2_DISTRO}-ros2-control \
+    ros-${ROS2_DISTRO}-ros2-controllers \
     libignition-transport11-dev \
     libignition-gazebo6-dev 
 

--- a/ros2-humble/custom/Dockerfile
+++ b/ros2-humble/custom/Dockerfile
@@ -60,16 +60,11 @@ COPY ./to_copy/nanorc /root/.nanorc
 COPY ./to_copy/tmux /root/.tmux.conf
 COPY ./to_copy/ranger /root/.config/ranger/rc.conf
 
-# Add developer and add it to sudo group
-RUN adduser --disabled-password --gecos '' developer 
-RUN adduser developer sudo 
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
 # Init ROS2 workspace
-RUN mkdir -p /home/developer/ros2_ws/src
-WORKDIR /home/developer/ros2_ws
+RUN mkdir -p /root/ros2_ws/src
+WORKDIR /root/ros2_ws
 RUN colcon build
-WORKDIR /home/developer/ros2_ws/src
+WORKDIR /root/ros2_ws/src
 
 # Modify .bashrc
 RUN echo "" >> ~/.bashrc
@@ -98,9 +93,9 @@ RUN sudo apt-get install -y \
     libignition-transport11-dev \
     libignition-gazebo6-dev 
 
-WORKDIR /home/developer/ros2_ws/src
+WORKDIR /root/ros2_ws/src
 RUN git clone https://github.com/gazebosim/ros_gz.git -b ${ROS2_DISTRO}
-WORKDIR /home/developer/ros2_ws
+WORKDIR /root/ros2_ws
 RUN sudo rosdep init
 RUN rosdep update
 RUN rosdep install -r --from-paths src -i -y --rosdistro ${ROS2_DISTRO}

--- a/ros2-humble/custom/Dockerfile
+++ b/ros2-humble/custom/Dockerfile
@@ -80,10 +80,10 @@ RUN echo "source /home/developer/ros2_ws/install/local_setup.bash" >> ~/.bashrc
 FROM ros2 as ign_gazebo
 
 # Gazebo installation 
-RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+RUN sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 RUN sudo apt-get update
-RUN sudo apt-get install -y gz-harmonic
+RUN sudo apt-get install -y ignition-fortress
 
 # ros2_gz
 RUN sudo apt-get install -y \
@@ -92,6 +92,9 @@ RUN sudo apt-get install -y \
     ros-${ROS2_DISTRO}-joint-state-publisher \
     ros-${ROS2_DISTRO}-ros2-control \
     ros-${ROS2_DISTRO}-ros2-controllers \
+    ros-${ROS2_DISTRO}-hardware-interface \
+    ros-${ROS2_DISTRO}-controller-interface \ 
+    ros-${ROS2_DISTRO}-controller-manager \
     libignition-transport11-dev \
     libignition-gazebo6-dev 
 

--- a/ros2-humble/custom/run_docker.sh
+++ b/ros2-humble/custom/run_docker.sh
@@ -15,7 +15,7 @@ docker run \
   --volume /tmp/.x11-unix:/tmp/.x11-unix \
   --volume ~/.ssh/ssh_auth_sock:/ssh-agent \
   --env SSH_AUTH_SOCK=/ssh-agent \
-  --env display=$display \
+  --env DISPLAY=$DISPLAY \
   --env TERM=xterm-256color \
   --name $CONTAINER_NAME \
   $IMAGE_NAME \


### PR DESCRIPTION
* Added multistage build for the gz harmonic, you can build gazebo with adding `target` argument to the `docker build` command as: 
```
docker build -t ros2_img:humble --target ign_gazebo
```
* Added `chmod +x` for `run_docker.sh` 
* Added `developer` user to put workspace into `/home/developer`
* changed `display=$display` to `DISPLAY=$DISPLAY` to enable GUI for GZ 